### PR TITLE
유니코드 공백으로 인한 path 오류 수정

### DIFF
--- a/module/file_processor.py
+++ b/module/file_processor.py
@@ -2,7 +2,6 @@ import re
 
 # 폴더 / 파일 저장시 특수문자 저장용 처리 클래스
 
-
 class FileProcessor:
     def remove_forbidden_str(self, string: str) -> str:
         """
@@ -17,10 +16,25 @@ class FileProcessor:
         # \t 과 \n제거 (\t -> 공백 , \n -> 공백)
         table = str.maketrans("\t\n", "  ")
         processed_string = processed_string.translate(table)
-        return processed_string.strip()
+        bprocessed_string = self.soft_strip_edges(processed_string)
+        return bprocessed_string.strip().rstrip(".")
 
     def remove_tag(self, string: str) -> str:
         # <tag>, &nbfs 등등 제거
         cleaner = re.compile("<.*?>|&([a-z0-9]+|#[0-9]{1,6}|#x[0-9a-f]{1,6});")
         string = re.sub(cleaner, "", string)
         return string
+
+    def soft_strip_edges(self, s: str) -> str:
+        # 경로명 앞 뒤 유니코드 공백 문자 제거
+        WINDOWS_WEIRD_SPACES = [
+            "\u00A0",  # NO-BREAK SPACE
+            "\u200B",  # ZERO WIDTH SPACE
+            "\u2009",  # THIN SPACE
+            "\u200A",  # HAIR SPACE
+            "\u3000",  # IDEOGRAPHIC SPACE
+            "\uFEFF",  # ZERO WIDTH NO-BREAK SPACE (BOM)
+        ]
+        
+        TRIM_CHARS = " \t\r\n" + "".join(WINDOWS_WEIRD_SPACES)
+        return s.strip(TRIM_CHARS)


### PR DESCRIPTION
Issue: 서브 타이틀 생성 시 드문 확률로 제목 끝에 특수 공백이 포함된 제목 생성
- 윈도우에서는 폴더 끝 공백을 허용하지 않아 자동으로 공백 제거되나, 인메모리 경로에선 공백이 남아 있어 경로를 찾지 못함
  - 특수 유니코드지만 윈도우에선 자동으로 공백으로 인식하고 제거하는 것으로 추정
- 다운로드 재시도 루프 발생

Fix:
- 경로 문자열 반환 직전 앞 뒤 특수 공백 모두 제거
- 마침표 또한 폴더명 끝에서는 자동 제거 되므로 제거
- 문제 생기던 곳에선 테스트 완료, 다른 이슈 더 있을 수도 있음
